### PR TITLE
Booking JS now loaded from CDN

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -21,7 +21,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
       textFormatter: 'https://unpkg.com/sprintf-js@1.1.1/dist/sprintf.min',
       uiFramework: 'https://unpkg.com/@rebelcode/ui-framework@0.1.1/dist/static/js/uiFramework',
-      calendar: 'https://unpkg.com/@rebelcode/vc-calendar@0.1.0/dist/vc-calender', //fix
+      stdLib: 'https://unpkg.com/@rebelcode/std-lib@0.1.2/dist/std-lib',
+      calendar: 'https://unpkg.com/@rebelcode/vc-calendar@0.1.0/dist/vc-calender',
       repeater: 'https://unpkg.com/@rebelcode/vc-repeater@0.1.0/dist/vc-repeater',
       selectionList: 'https://unpkg.com/@rebelcode/vc-selection-list@0.1.0/dist/vc-selection-list',
       tabs: 'https://unpkg.com/@rebelcode/vc-tabs@0.1.0/dist/vc-tabs',
@@ -50,6 +51,7 @@ document.addEventListener('DOMContentLoaded', function () {
     'vue',
     'vuex',
     'validate',
+    'stdLib',
     'axios',
     'calendar',
     'pluralize',

--- a/build.xml
+++ b/build.xml
@@ -6,9 +6,8 @@
     <property name="node_modules_dir" value="node_modules" />
     <property name="module_build_path" value="${module_base_dir}/${module_build_dir}" />
     <property name="node_modules_path" value="${module_base_dir}/${node_modules_dir}" />
-    <property name="node_modules_list" value="booking-js" />
 
-    <available property="npm_deps_installed" value="true" type="dir" file="${node_modules_path}" />
+    <available property="js_installed" value="true" type="dir" file="${node_modules_path}" />
 
     <target name="clean">
         <echo msg="Cleaning build files" />
@@ -20,20 +19,20 @@
         <mkdir dir="${module_build_path}" />
     </target>
 
-    <target name="install_npm">
-        <echo msg="Installing NPM dependencies" />
+    <target name="install_js">
+        <echo msg="Installing JS dependencies" />
         <exec command="npm install --no-bin-links" dir="${module_base_dir}" checkreturn="true" />
     </target>
 
-    <target name="maybe_install_npm" unless="npm_deps_installed">
-        <phingcall target="install_npm" />
+    <target name="maybe_install_js" unless="js_installed">
+        <phingcall target="install_js" />
     </target>
 
-    <target name="build_css_module" depends="clean,prepare,maybe_install_npm">
-        <echo msg="Building CSS module in ${module_base_dir}" />
+    <target name="build_css" depends="clean,prepare,maybe_install_js">
+        <echo msg="Building CSS in ${module_base_dir}" />
         <exec command="npm run build" dir="${module_base_dir}" />
     </target>
 
-    <target name="build" depends="build_css_module">
+    <target name="build" depends="build_css">
     </target>
 </project>

--- a/build.xml
+++ b/build.xml
@@ -8,7 +8,7 @@
     <property name="node_modules_path" value="${module_base_dir}/${node_modules_dir}" />
     <property name="node_modules_list" value="booking-js" />
 
-    <available property="js_installed" value="true" type="dir" file="${node_modules_path}" />
+    <available property="npm_deps_installed" value="true" type="dir" file="${node_modules_path}" />
 
     <target name="clean">
         <echo msg="Cleaning build files" />
@@ -20,25 +20,20 @@
         <mkdir dir="${module_build_path}" />
     </target>
 
-    <target name="install_js">
-        <echo msg="Installing JS dependencies" />
+    <target name="install_npm">
+        <echo msg="Installing NPM dependencies" />
         <exec command="npm install --no-bin-links" dir="${module_base_dir}" checkreturn="true" />
     </target>
 
-    <target name="maybe_install_js" unless="js_installed">
-        <phingcall target="install_js" />
+    <target name="maybe_install_npm" unless="npm_deps_installed">
+        <phingcall target="install_npm" />
     </target>
 
-    <target name="build_js_module">
-        <echo msg="Building JS module '${node_module_name}'" />
-        <exec command="npm run build -- --output-path='${module_build_path}/${node_module_name}'" dir="${node_modules_path}/${node_module_name}" />
+    <target name="build_css_module" depends="clean,prepare,maybe_install_npm">
+        <echo msg="Building CSS module in ${module_base_dir}" />
+        <exec command="npm run build" dir="${module_base_dir}" />
     </target>
 
-    <target name="build_js_modules" depends="clean,prepare,maybe_install_js">
-        <echo msg="Building JS modules in ${module_base_dir}" />
-        <foreach list="${node_modules_list}" param="node_module_name" target="build_js_module" />
-    </target>
-
-    <target name="build" depends="build_js_modules">
+    <target name="build" depends="build_css_module">
     </target>
 </project>

--- a/config/assets_urls_map.php
+++ b/config/assets_urls_map.php
@@ -3,8 +3,8 @@
 return [
     'require' => 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.js',
 
+    'bookings_ui/dist/app.min.js' => 'https://unpkg.com/@rebelcode/bookings-js@0.1.3/dist/js/app.min',
     'bookings_ui/assets/js/main.js' => plugins_url(WP_BOOKINGS_UI_MODULE_RELATIVE_DIR.'/assets/js/main.js', EDDBK_FILE),
-    'bookings_ui/dist/app.min.js' => plugins_url(WP_BOOKINGS_UI_MODULE_RELATIVE_DIR.'/dist/booking-js/app.min', EDDBK_FILE),
     'bookings_ui/dist/wp-booking-ui.css' => plugins_url(WP_BOOKINGS_UI_MODULE_RELATIVE_DIR.'/dist/wp-booking-ui.css', EDDBK_FILE),
 
     'cdn/fullcalendar.css' => 'https://cdnjs.cloudflare.com/ajax/libs/fullcalendar/3.8.0/fullcalendar.min.css',

--- a/package-lock.json
+++ b/package-lock.json
@@ -334,13 +334,6 @@
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
     },
-    "booking-js": {
-      "version": "github:RebelCode/bookings-js#0741ed7781633e6e6e7ac410d6ee1845e45662b3",
-      "dev": true,
-      "requires": {
-        "vue-wp-list-table": "1.1.0"
-      }
-    },
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
@@ -6150,12 +6143,6 @@
       "requires": {
         "indexof": "0.0.1"
       }
-    },
-    "vue-wp-list-table": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vue-wp-list-table/-/vue-wp-list-table-1.1.0.tgz",
-      "integrity": "sha512-j4/Bz6ZsM2Xv6icpih5NxMqY4dHJAwSrkU8abqrE//1aGWt5K43cAfpY9+HtUaZl78Ody1pTL0jOOjK+w1ELHg==",
-      "dev": true
     },
     "watchpack": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,10 @@
   "version": "0.1.0",
   "description": "Booking plugin application",
   "scripts": {
-    "watch:css": "./node_modules/.bin/webpack --watch",
-    "build:css": "./node_modules/.bin/webpack -p",
-    "build:js": "cd ./node_modules/booking-js/ && npm run build -- --output-path='booking-js' && cp -a ./booking-js/ ../../dist",
-    "build": "..."
+    "watch": "./node_modules/webpack/bin/webpack.js --watch",
+    "build": "./node_modules/webpack/bin/webpack.js -p"
   },
   "devDependencies": {
-    "booking-js": "github:RebelCode/bookings-js#0741ed7781633e6e6e7ac410d6ee1845e45662b3",
     "css-loader": "^0.28.9",
     "extract-text-webpack-plugin": "^3.0.2",
     "fast-sass-loader": "^1.4.0",


### PR DESCRIPTION
In this PR I've moved `bookings-js` to CDN and changed phing config to build ONLY CSS.

To build:
```
$ vagrant up
$ vagrant ssh
$ cd /var/www/project
$ phing -verbose
```

Phing will install NPM deps and run `npm run build` which will build CSS for module. 