### PR TITLE
Availability validation rule is fixed

### DIFF
--- a/templates/availability/service-availability-editor.phtml
+++ b/templates/availability/service-availability-editor.phtml
@@ -47,7 +47,7 @@
                     <div class="form-row__input">
                         <div class="form-row__input-with-description">
                             <datetime-picker class="datetime-picker--inline"
-                                             v-validate="'required|date_format:' + config.formats.datetime.tzFree + '|after:$start'"
+                                             v-validate="'required|date_format:' + config.formats.datetime.tzFree + '|after:$start' + (model.isAllDay ? ',true' : '')"
                                              name="end"
                                              @input="errors.remove('end')"
                                              v-model="model.end"

--- a/templates/availability/service-availability-editor.phtml
+++ b/templates/availability/service-availability-editor.phtml
@@ -46,6 +46,7 @@
                     </div>
                     <div class="form-row__input">
                         <div class="form-row__input-with-description">
+                            <!-- Params list for `after` datetime validation rule: {field for comparing},{are fields can be equal (`>=`) , default is `false` (`>`)} -->
                             <datetime-picker class="datetime-picker--inline"
                                              v-validate="'required|date_format:' + config.formats.datetime.tzFree + '|after:$start' + (model.isAllDay ? ',true' : '')"
                                              name="end"

--- a/templates/availability/service-availability-editor.phtml
+++ b/templates/availability/service-availability-editor.phtml
@@ -46,7 +46,7 @@
                     </div>
                     <div class="form-row__input">
                         <div class="form-row__input-with-description">
-                            <!-- Params list for `after` datetime validation rule: {field for comparing},{are fields can be equal (`>=`) , default is `false` (`>`)} -->
+                            <?php // Params list for `after` datetime validation rule: after:{field for comparing},{are fields can be equal (`>=`) , default is `false` (`>`)} ?>
                             <datetime-picker class="datetime-picker--inline"
                                              v-validate="'required|date_format:' + config.formats.datetime.tzFree + '|after:$start' + (model.isAllDay ? ',true' : '')"
                                              name="end"


### PR DESCRIPTION
Helps to fix https://github.com/RebelCode/bookings-js/issues/48

### Fix explanation
When we selecting "All day" in availability editor, validation rule should allow equal value of datetime for `start` and `end` fields. In order to achieve this I'm passing `true` as second parameter (`inclusion`) when `isAllDay === true`. It will allow comparing datetimes to be equal (rule becomes `after OR equal`) (https://baianat.github.io/vee-validate/guide/rules.html#after).