### PR TITLE
Enabled ability to configure service timezone displaying

### DIFF
--- a/templates/availability/tab-display-options.phtml
+++ b/templates/availability/tab-display-options.phtml
@@ -1,10 +1,10 @@
 <div class="wide-form">
     <div class="wide-form__header">
-        Calendar and timezone options
+        {{ _('Calendar and timezone options') }}
     </div>
     <div class="wide-form__row">
         <div class="wide-form__label" style="width: 100%;max-width: 600px">
-            Show dates and times on the site using the customer's timezone
+            {{ _("Show dates and times on the site using the customer's timezone") }}
         </div>
         <div class="wide-form__input">
             <bool-switcher v-model="useCustomerTimezone"></bool-switcher>
@@ -14,6 +14,6 @@
 
 <div class="wide-form">
     <div class="wide-form__header">
-        More options coming soon
+        {{ _('More options coming soon') }}
     </div>
 </div>

--- a/templates/availability/tab-display-options.phtml
+++ b/templates/availability/tab-display-options.phtml
@@ -4,9 +4,11 @@
     </div>
     <div class="wide-form__row">
         <div class="wide-form__label" style="width: 100%;max-width: 600px">
-            Dates and times are shown to the customer using their browser's timezone, both during the booking process and at checkout. Soon, this will be optional.
+            Show dates and times on the site using the customer's timezone
         </div>
-        <?php //<div class="wide-form__input"> <bool-switcher v-model="useCustomerTimezone"/> </div> ?>
+        <div class="wide-form__input">
+            <bool-switcher v-model="useCustomerTimezone"></bool-switcher>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
Helps to fix https://github.com/RebelCode/booking-wizard/issues/3 

This PR enables timezone config input on display options tab on download's nedit page.