### PR TITLE
Added error message if new session length is not uniq

### DIFF
--- a/templates/availability/tab-session-length.phtml
+++ b/templates/availability/tab-session-length.phtml
@@ -8,6 +8,7 @@
                            ref="sessionLength"
                            class="session-length__input"
                            :data-validation-error="_('Please enter a session length greater than 0.')"
+                           :data-uniqness-error="_('This session length already exists for this service.')"
                            @keydown.enter="addNewSession"
                     >
                     <select v-model="sessionTimeUnit">


### PR DESCRIPTION
Helps to fix 
https://github.com/RebelCode/bookings-js/pull/64 by adding new message that appears when user try to create session length with already existing duration.