### PR TITLE
Use REST API transformer (Part 2)

### DIFF
--- a/services.php
+++ b/services.php
@@ -16,6 +16,7 @@ use RebelCode\Bookings\WordPress\Module\Handlers\SaveSettingsHandler;
 use RebelCode\Bookings\WordPress\Module\Handlers\SettingsStateHandler;
 use RebelCode\Bookings\WordPress\Module\Handlers\VisibleStatusesHandler;
 use RebelCode\Bookings\WordPress\Module\Handlers\WizardLabelsHandler;
+use RebelCode\Bookings\WordPress\Module\ServiceListTransformer;
 use RebelCode\Bookings\WordPress\Module\SettingsContainer;
 use RebelCode\Bookings\WordPress\Module\TemplateManager;
 use \Psr\EventManager\EventManagerInterface;
@@ -239,16 +240,7 @@ return function ($eventManager, $eventFactory, $containerFactory) {
          * @since [*next-version*]
          */
         'eddbk_bookings_ui_service_list_transformer' => function (ContainerInterface $c) {
-            return new CallbackTransformer(function ($list) use ($c) {
-                $iterator = $this->_normalizeIterator($list);
-                $transformed = new TransformerIterator(
-                    $iterator,
-                    $c->get('eddbk_bookings_ui_service_transformer')
-                );
-                $array = $this->_normalizeArray($transformed);
-
-                return $array;
-            });
+            return new ServiceListTransformer($c->get('eddbk_bookings_ui_service_transformer'));
         },
 
         /*

--- a/src/ServiceListTransformer.php
+++ b/src/ServiceListTransformer.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace RebelCode\Bookings\WordPress\Module;
+
+use ArrayIterator;
+use Dhii\Exception\CreateInvalidArgumentExceptionCapableTrait;
+use Dhii\I18n\StringTranslatingTrait;
+use Dhii\Iterator\NormalizeIteratorCapableTrait;
+use Dhii\Transformer\TransformerInterface;
+use Dhii\Util\Normalization\NormalizeArrayCapableTrait;
+use IteratorIterator;
+use RebelCode\Transformers\TransformerIterator;
+use Iterator;
+use Traversable;
+
+/**
+ * A transformer for transforming lists of services.
+ *
+ * @since [*next-version*]
+ */
+class ServiceListTransformer implements TransformerInterface
+{
+    /* @since [*next-version*] */
+    use NormalizeArrayCapableTrait;
+
+    /* @since [*next-version*] */
+    use NormalizeIteratorCapableTrait;
+
+    /* @since [*next-version*] */
+    use CreateInvalidArgumentExceptionCapableTrait;
+
+    /* @since [*next-version*] */
+    use StringTranslatingTrait;
+
+    /**
+     * The transformer for a single service.
+     *
+     * @since [*next-version*]
+     *
+     * @var TransformerInterface
+     */
+    protected $serviceT9r;
+
+    /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
+     * @param TransformerInterface $serviceT9r The transformer for a single service.
+     */
+    public function __construct(TransformerInterface $serviceT9r)
+    {
+        $this->serviceT9r = $serviceT9r;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    public function transform($source)
+    {
+        $sourceIterator = $this->_normalizeIterator($source);
+        $transIterator  = $this->_createTransformerIterator($sourceIterator, $this->serviceT9r);
+
+        return $this->_normalizeArray($transIterator);
+    }
+
+    /**
+     * Creates a transformer iterator.
+     *
+     * @since [*next-version*]
+     *
+     * @param Iterator             $iterator    The iterator.
+     * @param TransformerInterface $transformer The transformer.
+     *
+     * @return TransformerIterator The created transformer iterator instance.
+     */
+    protected function _createTransformerIterator(Iterator $iterator, TransformerInterface $transformer)
+    {
+        return new TransformerIterator($iterator, $transformer);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    protected function _createArrayIterator(array $array)
+    {
+        return new ArrayIterator($array);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @since [*next-version*]
+     */
+    protected function _createTraversableIterator(Traversable $traversable)
+    {
+        return new IteratorIterator($traversable);
+    }
+}

--- a/src/WpBookingsUiModule.php
+++ b/src/WpBookingsUiModule.php
@@ -150,7 +150,7 @@ class WpBookingsUiModule extends AbstractBaseModule
         $this->_attach('wp_ajax_' . $c->get('wp_bookings_ui/settings/action'), $c->get('eddbk_bookings_update_settings_handler'));
 
         // Event for providing the booking services for the admin bookings UI
-        $this->_attach('eddbk_admin_bookings_ui_services', $c->get('eddbk_admin_bookings_ui_services_handler'));
+        $this->_attach('eddbk_admin_bookings_ui_services', $c->get('eddbk_bookings_ui_services_handler'));
     }
 
     /**


### PR DESCRIPTION
A continuation of #100 

Since the service list transformer needs normalization functionality, it is now wrapped into a class. Also fixes a service name error.